### PR TITLE
feat: added shell special chars support

### DIFF
--- a/src/v-45-46-47-48-49/utils/getCommandOutput.js
+++ b/src/v-45-46-47-48-49/utils/getCommandOutput.js
@@ -31,6 +31,12 @@ async function execCommunicate(argv, input = null, cancellable = null) {
     if (input !== null)
         flags |= Gio.SubprocessFlags.STDIN_PIPE;
 
+    const commandStr = argv.join(' ');
+    const shellSpecialChars = ['$', '`', '|', '>', '<'];
+    if (shellSpecialChars.some(feature => commandStr.includes(feature))) {
+        argv = ['/bin/sh', '-c', commandStr];
+    }
+
     const proc = new Gio.Subprocess({argv, flags});
     proc.init(cancellable);
 


### PR DESCRIPTION
I was trying to insert a command like:

`echo "$(whoami)@$(hostname)"`

but the shell special chars caused this error:
<img width="1719" height="519" alt="before" src="https://github.com/user-attachments/assets/d93156be-051b-479c-99c8-88deef6427f6" />

So I thought that wrapping the command in this way should solve it:

```javascript
const commandStr = argv.join(' ');
    const shellSpecialChars = ['$', '`', '|', '>', '<'];
    if (shellSpecialChars.some(feature => commandStr.includes(feature))) {
        argv = ['/bin/sh', '-c', commandStr];
    }
```
and it did: 

<img width="960" height="540" alt="after" src="https://github.com/user-attachments/assets/201d8331-e0b3-47cf-ad3d-b6f78901f6e4" />

I tested it in GNOME 49 and it works like a charm.

